### PR TITLE
Move multimedia access directly to return method to avoid nulling errors

### DIFF
--- a/src/components/ArticleCard.tsx
+++ b/src/components/ArticleCard.tsx
@@ -8,8 +8,6 @@ const ArticleCard = ({
   des_facet, org_facet, per_facet, geo_facet, multimedia, short_url,
 }: IArticle) => {
 
-  const imageUrl = multimedia[0].url;
-
   const formattedSection = subsection.length
     ? `${section} / ${subsection}`
     : section
@@ -18,11 +16,11 @@ const ArticleCard = ({
 
   return (
     <>
-    { multimedia.length &&
+    { multimedia &&
       <article
         className='article-card__container'
         style={{
-          backgroundImage: `url(${imageUrl})`
+          backgroundImage: `url(${multimedia[0].url})`
         }}
       >
         <div className='article-card__text-overlay'>


### PR DESCRIPTION
### Linked Issue(s)
- Closes #8 

### Testing
- n/a

### Refactors 
- Stop storing imageUrl error, as it inconsistently returns null; move to conditional render

### Technical Debt
- n/a

### Other Comments, Concerns, or Questions
- n/a

### Checklist
- [x] I have performed a self-review of my own code
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new console errors
